### PR TITLE
Update IndieEffects.js with option to choose old rendering method

### DIFF
--- a/Indie Effects Git/Assets/IndieEffects/JS Classes/IndieEffects.js
+++ b/Indie Effects Git/Assets/IndieEffects/JS Classes/IndieEffects.js
@@ -18,6 +18,10 @@ var DepthCam : GameObject;
 @Range(0,0.04)
 var latency : float;
 
+var useOldVersion : boolean; //enable old rendering method
+var myCamera : Camera; //cache camera and transform component for 
+private var myTransform : Transform; //performance
+
 static function FullScreenQuad(renderMat : Material) {
 	GL.PushMatrix();
 	for (var i = 0; i < renderMat.passCount; ++i) {
@@ -76,6 +80,8 @@ var prevRect : Rect;
 var asp : float;
 var dom : GameObject;
 function OnPreRender () {
+	if( !useOldVersion ){
+		
 	asp = camera.pixelWidth/camera.pixelHeight;
 	if (!DepthCam){
 		DepthCam = new GameObject("DepthCamera",Camera);
@@ -106,9 +112,47 @@ function OnPreRender () {
 		RT.ReadPixels(Rect(camera.pixelRect.x,camera.pixelRect.y,textureSize,textureSize), 0, 0);
 		RT.Apply();
 	}
+	
+	}
+}
+
+function OnPostRender() {
+	if( useOldVersion ) {		
+		if( DNRequire ) {
+			//DN-Texture generation not ready
+			if (!DepthCam){
+				DepthCam = new GameObject("DepthCamera",Camera);
+				DepthCam.camera.CopyFrom(myCamera);
+				DepthCam.camera.depth = myCamera.depth-2;
+			}
+
+			DepthCam.transform.position = myTransform.position;
+			DepthCam.transform.rotation = myTransform.rotation;
+			DepthCam.camera.SetReplacementShader(DepthShader, "RenderType");
+			DepthCam.camera.aspect = myCamera.aspect;
+			DepthCam.camera.pixelRect = myCamera.pixelRect;
+			DepthCam.camera.Render();
+			DNBuffer.Resize(myCamera.pixelWidth, myCamera.pixelHeight, TextureFormat.RGB24, false);
+			DNBuffer.ReadPixels(myCamera.pixelRect, 0, 0);
+			DNBuffer.Apply();
+		
+		}
+		RT.Resize(myCamera.pixelWidth, myCamera.pixelHeight, TextureFormat.RGB24, false);
+		RT.ReadPixels(myCamera.pixelRect, 0, 0);
+	   
+		RT.Apply();	
+	}
 }
 
 function Start () {
+	
+	myTransform = transform;
+	myCamera = GetComponent(Camera);
+	
+	
+	
+	if( !useOldVersion ){
+		
 	capture = true;
 	RT = new Texture2D(textureSize, textureSize, TextureFormat.RGB24, false);
 	RT.wrapMode = TextureWrapMode.Clamp;
@@ -117,5 +161,14 @@ function Start () {
 	while(true) {
 		capture = true;
 		yield WaitForSeconds(latency);
+	}
+	
+	} else {
+		//old approuch
+		//possible for splitscreen too
+		RT = new Texture2D(myCamera.pixelWidth, myCamera.pixelHeight, TextureFormat.RGB24, false);
+		//RT.wrapMode = TextureWrapMode.Clamp;
+		DNBuffer = new Texture2D(myCamera.pixelWidth, myCamera.pixelHeight, TextureFormat.ARGB32, false);
+		
 	}
 }


### PR DESCRIPTION
added the old rendering method, useOldVersion switches between rendering mehtods, changing only at start possible. DepthNormal Texture generation not ready yet.
